### PR TITLE
Add org.w3c.dom.events=3.0.0 import

### DIFF
--- a/org.openscience.cdk.knime/META-INF/MANIFEST.MF
+++ b/org.openscience.cdk.knime/META-INF/MANIFEST.MF
@@ -214,3 +214,4 @@ Export-Package: javax.vecmath,
 Bundle-Activator: org.openscience.cdk.knime.CDKNodePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Import-Package: org.w3c.dom.events;version="3.0.0"


### PR DESCRIPTION
This allows the extension to run in the upcoming KNIME 4.4.