### PR TITLE
Make the atom and bond list optional fixes #10

### DIFF
--- a/org.openscience.cdk.knime/src/org/openscience/cdk/knime/nodes/depiction/DepictionNodeDialog.java
+++ b/org.openscience.cdk.knime/src/org/openscience/cdk/knime/nodes/depiction/DepictionNodeDialog.java
@@ -109,9 +109,6 @@ public class DepictionNodeDialog extends DefaultNodeSettingsPane
 		allowedTypes[0] = IntValue.class;
 		allowedTypes[1] = (Class<? extends DataValue>) ListDataValue.class;
 		
-		// allowedTypes[1] = StringValue.class; // Work around to allow null
-		// selection
-
 		createNewGroup("Highlights");
 		setHorizontalPlacement(false);
 		addDialogComponent(new DialogComponentBoolean(
@@ -127,7 +124,6 @@ public class DepictionNodeDialog extends DefaultNodeSettingsPane
 
 		atomHighlightSetting.addChangeListener(new ChangeListener()
 		{
-
 			@Override
 			public void stateChanged(ChangeEvent e)
 			{
@@ -141,7 +137,7 @@ public class DepictionNodeDialog extends DefaultNodeSettingsPane
 		addDialogComponent(new DialogComponentBoolean(atomHighlightSetting, "Highlight atoms"));
 
 		DialogComponentColumnNameSelection atomHighlight = new DialogComponentColumnNameSelection(atomHighlights,
-				"Atom index positions", 0, allowedTypes);
+				"Atom index positions", 0, false, allowedTypes);
 
 		addDialogComponent(atomHighlight);
 		addDialogComponent(new DialogComponentColorChooser(
@@ -171,7 +167,7 @@ public class DepictionNodeDialog extends DefaultNodeSettingsPane
 
 		addDialogComponent(new DialogComponentBoolean(bondHighlightSetting, "Highlight bonds"));
 		DialogComponentColumnNameSelection bondHighlight = new DialogComponentColumnNameSelection(bondHighlights,
-				"Bond index positions", 0, allowedTypes);
+				"Bond index positions", 0, false, allowedTypes);
 
 		addDialogComponent(bondHighlight);
 		addDialogComponent(new DialogComponentColorChooser(

--- a/org.openscience.cdk.knime/src/org/openscience/cdk/knime/nodes/depiction/DepictionNodeModel.java
+++ b/org.openscience.cdk.knime/src/org/openscience/cdk/knime/nodes/depiction/DepictionNodeModel.java
@@ -216,13 +216,11 @@ public class DepictionNodeModel extends CdkSimpleStreamableFunctionNodeModel
 			 */
 			private List<Integer> getPositions(DataTableSpec spec, DataRow row, int colIndex)
 			{
-
 				List<Integer> positions = new ArrayList<Integer>();
-//				Integer[] positions = null;
 				
 				if (row.getCell(colIndex).isMissing())
 				{
-					
+					// Nothing to add
 				}
 				else if (spec.getColumnSpec(colIndex).getType().isCompatible(IntValue.class))
 				{
@@ -249,7 +247,6 @@ public class DepictionNodeModel extends CdkSimpleStreamableFunctionNodeModel
 				}
 
 				return positions;
-//				return Ints.toArray(positions);
 			}
 		};
 	}


### PR DESCRIPTION
Fixes #10, make the selection of the atom and the bonds optional
with allows for using a table with just structures when no highlighting
is desired

