### PR TITLE
Fixes #11 If SMILES is blank don't try to update structures in dialog

### DIFF
--- a/org.openscience.cdk.knime/src/org/openscience/cdk/knime/nodes/sssearch/SSSearchNodeDialog.java
+++ b/org.openscience.cdk.knime/src/org/openscience/cdk/knime/nodes/sssearch/SSSearchNodeDialog.java
@@ -118,7 +118,10 @@ public class SSSearchNodeDialog extends NodeDialogPane {
 
 		if (m_settings.getSmiles() != null) {
 			try {
-				m_panel.loadStructures(m_settings.getSmiles());
+				String smiles = m_settings.getSmiles();
+				
+				if(!smiles.isBlank())
+					m_panel.loadStructures(m_settings.getSmiles());
 			} catch (Exception ex) {
 				LOGGER.error(ex.getMessage(), ex);
 				throw new NotConfigurableException(ex.getMessage());


### PR DESCRIPTION
Fixes #11 If the SMILES saved in the settings is blank, which can happen when
opening the node dialog and configuring to use  a SMILES string an error
is thrown when closing and reopening the dialog.

Issue resolved simply by checking if the SMILES save is a blank string.